### PR TITLE
Test/dockerize an api

### DIFF
--- a/build/server/gateway/Dockerfile
+++ b/build/server/gateway/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.21 AS build-stage
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . ./
+RUN go build -o /app/gateway-api ./cmd/server/gateway/main.go
+
+FROM gcr.io/distroless/base-debian12 AS build-release-stage
+WORKDIR /
+COPY --from=build-stage /app/gateway-api /gateway-api
+ENTRYPOINT ["/gateway-api"]

--- a/cmd/server/gateway/main.go
+++ b/cmd/server/gateway/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 
 	v1 "github.com/volovikariel/IdentityManager/internal/server/gateway/v1"
@@ -13,9 +14,10 @@ import (
 
 func main() {
 	serverConfig := &config.Server{}
-	flag.StringVar(&serverConfig.Port, "p", config.DEFAULT_PORT, "Port to listen on")
 	flag.StringVar(&serverConfig.Host, "h", config.DEFAULT_HOST, "Host to listen on")
+	flag.StringVar(&serverConfig.Port, "p", config.DEFAULT_PORT, "Port to listen on")
 	flag.Parse()
+	fmt.Println(serverConfig.Host)
 	server := v1.NewServer(serverConfig)
 
 	memoryStore := &models.InMemoryUserStore{}

--- a/cmd/server/gateway/main.go
+++ b/cmd/server/gateway/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"net/http"
 
 	v1 "github.com/volovikariel/IdentityManager/internal/server/gateway/v1"
@@ -17,7 +16,6 @@ func main() {
 	flag.StringVar(&serverConfig.Host, "h", config.DEFAULT_HOST, "Host to listen on")
 	flag.StringVar(&serverConfig.Port, "p", config.DEFAULT_PORT, "Port to listen on")
 	flag.Parse()
-	fmt.Println(serverConfig.Host)
 	server := v1.NewServer(serverConfig)
 
 	memoryStore := &models.InMemoryUserStore{}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,18 @@
 ![Workflow Badge](https://github.com/volovikariel/IdentityManager/actions/workflows/go.yml/badge.svg)
 
+# Running the standalone parts
+## Gateway API Server
+Build the image: `docker build -f build/server/gateway/Dockerfile -t gateway-api .`
+
+Run the image: `HOST_NAME='' HOST_PORT=10000 CONTAINER_PORT=8080; docker run -d --expose "$CONTAINER_PORT" -p "$HOST_PORT:$CONTAINER_PORT" --name gateway-api gateway-api:latest -h "$HOST_NAME" -p "$CONTAINER_PORT"`
+
+**Note**: You can specify the host name, host port, and container ports in the `docker run` command.
+
+You should now be able to access the Gateway API Server at: `http://localhost:HOST_PORT` (e.g: `curl localhost:10000`)
+
+Stop the container: `docker stop gateway-api`
+Remove the container: `docker rm gateway-api`
+
 # APIs
 ## Gateway API Server
 [Docs](https://volovikariel.github.io/IdentityManager/apis/server/gateway_api.html)


### PR DESCRIPTION
Gateway API is now Dockerized, and instructions on how to set it up are now available in the README :partying_face: 