### PR TITLE
K8s deployment gateway api

### DIFF
--- a/build/server/gateway/deployment.yaml
+++ b/build/server/gateway/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway-api-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gateway-api
+  template:
+    metadata:
+      labels:
+        app: gateway-api
+    spec:
+      containers:
+      - name: gateway-api
+        image: gateway-api:latest
+        # We are using a local image
+        imagePullPolicy: Never
+        ports:
+        - containerPort: 10000
+          name: gateway-api
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        args: ["-h", "", "-p", "10000"]

--- a/build/server/gateway/service.yaml
+++ b/build/server/gateway/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-api-service
+spec:
+  type: NodePort
+  ports:
+  - name: service-port
+    protocol: TCP
+    port: 10000
+    nodePort: 30000
+    targetPort: 10000
+  selector:
+    app: gateway-api

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,35 +2,72 @@
 
 # Running the standalone parts (Docker)
 ## Gateway API Server
-Build the image: `docker build -f build/server/gateway/Dockerfile -t gateway-api .`
+Build the image: 
+```
+docker build -f build/server/gateway/Dockerfile -t gateway-api .
+```
 
-Run the image: `HOST_NAME='' HOST_PORT=10000 CONTAINER_PORT=8080; docker run -d --expose "$CONTAINER_PORT" -p "$HOST_PORT:$CONTAINER_PORT" --name gateway-api gateway-api:latest -h "$HOST_NAME" -p "$CONTAINER_PORT"`
+Run the image:
+```
+HOST_NAME='' HOST_PORT=10000 CONTAINER_PORT=8080; \
+docker run -d \
+--expose "$CONTAINER_PORT" \
+-p "$HOST_PORT:$CONTAINER_PORT" \
+--name gateway-api \
+gateway-api:latest \
+-h "$HOST_NAME" \
+-p "$CONTAINER_PORT"
+```
 
 **Note**: You can specify the host name, host port, and container ports in the `docker run` command.
 
 You should now be able to access the Gateway API Server at: `http://localhost:HOST_PORT` (e.g: `curl localhost:10000`)
 
-Stop the container: `docker stop gateway-api`
+Stop the container:
+```
+docker stop gateway-api
+```
 
-Remove the container: `docker rm gateway-api`
+Remove the container:
+```
+docker rm gateway-api
+```
 
 # Running the individual parts (Kubernetes)
 ## Gateway API Server
 Build its Docker image.
 
-Create a Kubernetes cluster: `minikube start`
+Create a Kubernetes cluster:
+```
+minikube start
+```
 
-Create the Gateway API Server Deployment: `kubectl apply -f ./build/server/gateway/deployment.yaml`
+Create the Gateway API Server Deployment:
+```
+kubectl apply -f ./build/server/gateway/deployment.yaml
+```
 
-Create the Gateway API Server Service: `kubectl apply -f ./build/server/gateway/service.yaml`
+Create the Gateway API Server Service:
+```
+kubectl apply -f ./build/server/gateway/service.yaml
+```
 
-**Note**: You should now be able to access the Gateway API Server at: `http://$(minikube ip):30000`
+**Note**: You should now be able to access the Gateway API Server at `http://$(minikube ip):30000` (e.g: `curl http://$(minikube ip):30000`)
 
-Delete the service: `kubectl delete service gateway-api-service`
+Delete the service:
+```
+kubectl delete service gateway-api-service
+```
 
-Delete the deployment: `kubectl delete deployment gateway-api-deployment`
+Delete the deployment:
+```
+kubectl delete deployment gateway-api-deployment
+```
 
-Delete the cluster: `minikube delete`
+Delete the cluster:
+```
+minikube delete
+```
 
 # APIs
 ## Gateway API Server

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ![Workflow Badge](https://github.com/volovikariel/IdentityManager/actions/workflows/go.yml/badge.svg)
 
-# Running the standalone parts
+# Running the standalone parts (Docker)
 ## Gateway API Server
 Build the image: `docker build -f build/server/gateway/Dockerfile -t gateway-api .`
 
@@ -13,6 +13,24 @@ You should now be able to access the Gateway API Server at: `http://localhost:HO
 Stop the container: `docker stop gateway-api`
 
 Remove the container: `docker rm gateway-api`
+
+# Running the individual parts (Kubernetes)
+## Gateway API Server
+Build its Docker image.
+
+Create a Kubernetes cluster: `minikube start`
+
+Create the Gateway API Server Deployment: `kubectl apply -f ./build/server/gateway/deployment.yaml`
+
+Create the Gateway API Server Service: `kubectl apply -f ./build/server/gateway/service.yaml`
+
+**Note**: You should now be able to access the Gateway API Server at: `http://$(minikube ip):30000`
+
+Delete the service: `kubectl delete service gateway-api-service`
+
+Delete the deployment: `kubectl delete deployment gateway-api-deployment`
+
+Delete the cluster: `minikube delete`
 
 # APIs
 ## Gateway API Server

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,12 +3,12 @@
 # Running the standalone parts (Docker)
 ## Gateway API Server
 Build the image: 
-```
+```bash
 docker build -f build/server/gateway/Dockerfile -t gateway-api .
 ```
 
 Run the image:
-```
+```bash
 HOST_NAME='' HOST_PORT=10000 CONTAINER_PORT=8080; \
 docker run -d \
 --expose "$CONTAINER_PORT" \
@@ -24,12 +24,12 @@ gateway-api:latest \
 You should now be able to access the Gateway API Server at: `http://localhost:HOST_PORT` (e.g: `curl localhost:10000`)
 
 Stop the container:
-```
+```bash
 docker stop gateway-api
 ```
 
 Remove the container:
-```
+```bash
 docker rm gateway-api
 ```
 
@@ -38,34 +38,34 @@ docker rm gateway-api
 Build its Docker image.
 
 Create a Kubernetes cluster:
-```
+```bash
 minikube start
 ```
 
 Create the Gateway API Server Deployment:
-```
+```bash
 kubectl apply -f ./build/server/gateway/deployment.yaml
 ```
 
 Create the Gateway API Server Service:
-```
+```bash
 kubectl apply -f ./build/server/gateway/service.yaml
 ```
 
 **Note**: You should now be able to access the Gateway API Server at `http://$(minikube ip):30000` (e.g: `curl http://$(minikube ip):30000`)
 
 Delete the service:
-```
+```bash
 kubectl delete service gateway-api-service
 ```
 
 Delete the deployment:
-```
+```bash
 kubectl delete deployment gateway-api-deployment
 ```
 
 Delete the cluster:
-```
+```bash
 minikube delete
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ gateway-api:latest \
 
 **Note**: You can specify the host name, host port, and container ports in the `docker run` command.
 
-You should now be able to access the Gateway API Server at: `http://localhost:HOST_PORT` (e.g: `curl localhost:10000`)
+You should now be able to access the Gateway API Server at: `http://localhost:$HOST_PORT` (e.g: `curl localhost:$HOST_PORT`, or `curl localhost:10000`)
 
 Stop the container:
 ```bash


### PR DESCRIPTION
We can now create a super-duper K8S deployment of the Docker app, which will allow us to scale it (manually or automatically), and later on allow it to interact with various other services.

Completely new to Kubernetes at this point so, the `service` and `deployment` YAML files will probably change a lot in the near future! 